### PR TITLE
MAYH-5797 query all offsets at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,18 @@ FROM golang:alpine
 
 MAINTAINER LinkedIn Burrow "https://github.com/linkedin/Burrow"
 
-RUN apk add --update bash curl git && apk add ca-certificates wget && update-ca-certificates && rm -rf /var/cache/apk/*
-
-RUN curl -sSO https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm && \
-  chmod +x gpm && mv gpm /usr/local/bin
+RUN apk add --no-cache curl bash git ca-certificates wget \
+ && update-ca-certificates \
+ && curl -sSO https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm \
+ && chmod +x gpm \
+ && mv gpm /usr/local/bin
 
 ADD . $GOPATH/src/github.com/linkedin/Burrow
-RUN cd $GOPATH/src/github.com/linkedin/Burrow && gpm install && go install && mv $GOPATH/bin/Burrow $GOPATH/bin/burrow
+RUN cd $GOPATH/src/github.com/linkedin/Burrow \
+ && gpm install \
+ && go install \
+ && mv $GOPATH/bin/Burrow $GOPATH/bin/burrow \
+ && apk del git curl wget
 
 ADD docker-config /etc/burrow
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine
 
 MAINTAINER LinkedIn Burrow "https://github.com/linkedin/Burrow"
 
-RUN apk add --update bash curl git && rm -rf /var/cache/apk/*
+RUN apk add --update bash curl git && apk add ca-certificates wget && update-ca-certificatesrm -rf /var/cache/apk/*
 
 RUN wget https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm && chmod +x gpm && mv gpm /usr/local/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine
 
 MAINTAINER LinkedIn Burrow "https://github.com/linkedin/Burrow"
 
-RUN apk add --update bash curl git && apk add ca-certificates wget && update-ca-certificatesrm -rf /var/cache/apk/*
+RUN apk add --update bash curl git && apk add ca-certificates wget && update-ca-certificates && rm -rf /var/cache/apk/*
 
 RUN wget https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm && chmod +x gpm && mv gpm /usr/local/bin
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ go install
 
 ### Running Burrow
 ```
-$ $GOPATH/bin/burrow --config path/to/burrow.cfg
+$ $GOPATH/bin/Burrow --config path/to/burrow.cfg
 ```
 
 ### Using Docker

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ If you have not yet installed the [Go Package Manager](https://github.com/pote/g
 
 ### Build and Install
 ```
-$ go get github.com/linkedin/burrow
-$ cd $GOPATH/src/github.com/linkedin/burrow
+$ go get github.com/linkedin/Burrow
+$ cd $GOPATH/src/github.com/linkedin/Burrow
 $ gpm install
 $ go install
 ```

--- a/config.go
+++ b/config.go
@@ -37,6 +37,7 @@ type BurrowConfig struct {
 		ClientID       string `gcfg:"client-id"`
 		GroupBlacklist string `gcfg:"group-blacklist"`
 		GroupWhitelist string `gcfg:"group-whitelist"`
+		StdoutLogfile  string `gcfg:"stdout-logfile"`
 	}
 	Zookeeper struct {
 		Hosts    []string `gcfg:"hostname"`

--- a/config.go
+++ b/config.go
@@ -285,7 +285,7 @@ func ValidateConfig(app *ApplicationContext) error {
 				}
 			}
 			if len(cfg.ZookeeperPath) == 0 {
-                                errs = append(errs, fmt.Sprintf("No Zookeeper paths specified for cluster %s", cluster))
+				errs = append(errs, fmt.Sprintf("No Zookeeper paths specified for cluster %s", cluster))
 			} else {
 				for _, zkpath := range cfg.ZookeeperPath {
 					if zkpath == "" {

--- a/config.go
+++ b/config.go
@@ -74,6 +74,7 @@ type BurrowConfig struct {
 	Httpserver struct {
 		Enable bool `gcfg:"server"`
 		Port   int  `gcfg:"port"`
+		Listen []string `gcfg:"listen"`
 	}
 	Notify struct {
 		Interval int64 `gcfg:"interval"`
@@ -324,8 +325,16 @@ func ValidateConfig(app *ApplicationContext) error {
 
 	// HTTP Server
 	if app.Config.Httpserver.Enable {
-		if app.Config.Httpserver.Port == 0 {
-			errs = append(errs, "HTTP server port is not specified")
+		if len(app.Config.Httpserver.Listen) == 0 {
+			if app.Config.Httpserver.Port == 0 {
+				errs = append(errs, "HTTP server port is not specified")
+			}
+			listenPort := fmt.Sprintf(":%v", app.Config.Httpserver.Port)
+			app.Config.Httpserver.Listen = append(app.Config.Httpserver.Listen, listenPort)
+		} else {
+			if app.Config.Httpserver.Port != 0 {
+				errs = append(errs, "Either HTTP server port or listen can be specified, but not both")
+			}
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -57,7 +57,7 @@ type BurrowConfig struct {
 	Storm map[string]*struct {
 		Zookeepers    []string `gcfg:"zookeeper"`
 		ZookeeperPort int      `gcfg:"zookeeper-port"`
-		ZookeeperPath string   `gcfg:"zookeeper-path"`
+		ZookeeperPath []string `gcfg:"zookeeper-path"`
 	}
 	Tickers struct {
 		BrokerOffsets int `gcfg:"broker-offsets"`
@@ -284,11 +284,15 @@ func ValidateConfig(app *ApplicationContext) error {
 					errs = append(errs, hostlistError)
 				}
 			}
-			if cfg.ZookeeperPath == "" {
-				errs = append(errs, fmt.Sprintf("Zookeeper path is not specified for cluster %s", cluster))
+			if len(cfg.ZookeeperPath) == 0 {
+                                errs = append(errs, fmt.Sprintf("No Zookeeper paths specified for cluster %s", cluster))
 			} else {
-				if !validateZookeeperPath(cfg.ZookeeperPath) {
-					errs = append(errs, fmt.Sprintf("Zookeeper path is not valid for cluster %s", cluster))
+				for _, zkpath := range cfg.ZookeeperPath {
+					if zkpath == "" {
+						errs = append(errs, fmt.Sprintf("Zookeeper path is not specified for cluster %s", cluster))
+					} else if !validateZookeeperPath(zkpath) {
+						errs = append(errs, fmt.Sprintf("Zookeeper path is not valid for cluster %s", cluster))
+					}
 				}
 			}
 		}

--- a/config.go
+++ b/config.go
@@ -25,9 +25,12 @@ import (
 
 // Configuration definition
 type ClientProfile struct {
-	ClientID    string `gcfg:"client-id"`
-	TLS         bool   `gcfg:"tls"`
-	TLSNoVerify bool   `gcfg:"tls-noverify"`
+	ClientID        string `gcfg:"client-id"`
+	TLS             bool   `gcfg:"tls"`
+	TLSNoVerify     bool   `gcfg:"tls-noverify"`
+	TLSCertFilePath string  `gcfg:"tls-certfilepath"`
+	TLSKeyFilePath  string  `gcfg:"tls-keyfilepath"`
+	TLSCAFilePath   string  `gcfg:"tls-cafilepath"`
 }
 type BurrowConfig struct {
 	General struct {

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -45,6 +45,9 @@ expire-group=604800
 [httpserver]
 server=on
 port=8000
+; Alternatively, use listen (cannot be specified when port is)
+; listen=host:port
+; listen=host2:port2
 
 [smtp]
 server=mailserver.example.com

--- a/consumer_group_members.go
+++ b/consumer_group_members.go
@@ -1,0 +1,35 @@
+package main
+
+type ConsumerGroupMemberAssignment struct {
+	Version  int16
+	Topics   map[string][]int32
+	UserData []byte
+}
+
+func (m *ConsumerGroupMemberAssignment) decode(pd packetDecoder) (err error) {
+	if m.Version, err = pd.getInt16(); err != nil {
+		return
+	}
+
+	var topicLen int
+	if topicLen, err = pd.getArrayLength(); err != nil {
+		return
+	}
+
+	m.Topics = make(map[string][]int32, topicLen)
+	for i := 0; i < topicLen; i++ {
+		var topic string
+		if topic, err = pd.getString(); err != nil {
+			return
+		}
+		if m.Topics[topic], err = pd.getInt32Array(); err != nil {
+			return
+		}
+	}
+
+	if m.UserData, err = pd.getBytes(); err != nil {
+		return
+	}
+
+	return nil
+}

--- a/docker-config/burrow.cfg
+++ b/docker-config/burrow.cfg
@@ -1,7 +1,6 @@
 [general]
 logconfig=/etc/burrow/logging.cfg
 group-blacklist=^(console-consumer-|python-kafka-consumer-).*$
-stdout-logfile=burrow.out
 
 [zookeeper]
 hostname=zookeeper

--- a/docker-config/burrow.cfg
+++ b/docker-config/burrow.cfg
@@ -1,6 +1,7 @@
 [general]
 logconfig=/etc/burrow/logging.cfg
 group-blacklist=^(console-consumer-|python-kafka-consumer-).*$
+stdout-logfile=burrow.out
 
 [zookeeper]
 hostname=zookeeper

--- a/docker-config/logging.cfg
+++ b/docker-config/logging.cfg
@@ -1,6 +1,6 @@
 <seelog minlevel="debug">
   <outputs formatid="main">
-    <rollingfile type="date" filename="/var/tmp/burrow/burrow.log" datepattern="2006-01-02" maxrolls="7" />
+    <console />
   </outputs>
   <formats>
     <format id="main" format="%Date(2006-01-02 15:04:05) [%LEVEL] %Msg%n"/>

--- a/docker-config/logging.cfg
+++ b/docker-config/logging.cfg
@@ -1,4 +1,4 @@
-<seelog minlevel="debug">
+<seelog minlevel="info">
   <outputs formatid="main">
     <rollingfile type="date" filename="/var/tmp/burrow/burrow.log" datepattern="2006-01-02" maxrolls="7" />
   </outputs>

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrOutOfBrokers is the error returned when the client has run out of brokers to talk to because all of them errored
+// or otherwise failed to respond.
+var ErrOutOfBrokers = errors.New("kafka: client has run out of available brokers to talk to (Is your cluster reachable?)")
+
+// ErrClosedClient is the error returned when a method is called on a client that has been closed.
+var ErrClosedClient = errors.New("kafka: tried to use a client that was closed")
+
+// ErrIncompleteResponse is the error returned when the server returns a syntactically valid response, but it does
+// not contain the expected information.
+var ErrIncompleteResponse = errors.New("kafka: response did not contain all the expected topic/partition blocks")
+
+// ErrInvalidPartition is the error returned when a partitioner returns an invalid partition index
+// (meaning one outside of the range [0...numPartitions-1]).
+var ErrInvalidPartition = errors.New("kafka: partitioner returned an invalid partition index")
+
+// ErrAlreadyConnected is the error returned when calling Open() on a Broker that is already connected or connecting.
+var ErrAlreadyConnected = errors.New("kafka: broker connection already initiated")
+
+// ErrNotConnected is the error returned when trying to send or call Close() on a Broker that is not connected.
+var ErrNotConnected = errors.New("kafka: broker not connected")
+
+// ErrInsufficientData is returned when decoding and the packet is truncated. This can be expected
+// when requesting messages, since as an optimization the server is allowed to return a partial message at the end
+// of the message set.
+var ErrInsufficientData = errors.New("kafka: insufficient data to decode packet, more bytes expected")
+
+// ErrShuttingDown is returned when a producer receives a message during shutdown.
+var ErrShuttingDown = errors.New("kafka: message received by producer in process of shutting down")
+
+// ErrMessageTooLarge is returned when the next message to consume is larger than the configured Consumer.Fetch.Max
+var ErrMessageTooLarge = errors.New("kafka: message is larger than Consumer.Fetch.Max")
+
+// PacketEncodingError is returned from a failure while encoding a Kafka packet. This can happen, for example,
+// if you try to encode a string over 2^15 characters in length, since Kafka's encoding rules do not permit that.
+type PacketEncodingError struct {
+	Info string
+}
+
+func (err PacketEncodingError) Error() string {
+	return fmt.Sprintf("kafka: error encoding packet: %s", err.Info)
+}
+
+// PacketDecodingError is returned when there was an error (other than truncated data) decoding the Kafka broker's response.
+// This can be a bad CRC or length field, or any other invalid value.
+type PacketDecodingError struct {
+	Info string
+}
+
+func (err PacketDecodingError) Error() string {
+	return fmt.Sprintf("kafka: error decoding packet: %s", err.Info)
+}
+
+// ConfigurationError is the type of error returned from a constructor (e.g. NewClient, or NewConsumer)
+// when the specified configuration is invalid.
+type ConfigurationError string
+
+func (err ConfigurationError) Error() string {
+	return "kafka: invalid configuration (" + string(err) + ")"
+}
+
+// KError is the type of error that can be returned directly by the Kafka broker.
+// See https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-ErrorCodes
+type KError int16
+
+// Numeric error codes returned by the Kafka server.
+const (
+	ErrNoError                         KError = 0
+	ErrUnknown                         KError = -1
+	ErrOffsetOutOfRange                KError = 1
+	ErrInvalidMessage                  KError = 2
+	ErrUnknownTopicOrPartition         KError = 3
+	ErrInvalidMessageSize              KError = 4
+	ErrLeaderNotAvailable              KError = 5
+	ErrNotLeaderForPartition           KError = 6
+	ErrRequestTimedOut                 KError = 7
+	ErrBrokerNotAvailable              KError = 8
+	ErrReplicaNotAvailable             KError = 9
+	ErrMessageSizeTooLarge             KError = 10
+	ErrStaleControllerEpochCode        KError = 11
+	ErrOffsetMetadataTooLarge          KError = 12
+	ErrOffsetsLoadInProgress           KError = 14
+	ErrConsumerCoordinatorNotAvailable KError = 15
+	ErrNotCoordinatorForConsumer       KError = 16
+	ErrInvalidTopic                    KError = 17
+	ErrMessageSetSizeTooLarge          KError = 18
+	ErrNotEnoughReplicas               KError = 19
+	ErrNotEnoughReplicasAfterAppend    KError = 20
+	ErrInvalidRequiredAcks             KError = 21
+	ErrIllegalGeneration               KError = 22
+	ErrInconsistentGroupProtocol       KError = 23
+	ErrInvalidGroupId                  KError = 24
+	ErrUnknownMemberId                 KError = 25
+	ErrInvalidSessionTimeout           KError = 26
+	ErrRebalanceInProgress             KError = 27
+	ErrInvalidCommitOffsetSize         KError = 28
+	ErrTopicAuthorizationFailed        KError = 29
+	ErrGroupAuthorizationFailed        KError = 30
+	ErrClusterAuthorizationFailed      KError = 31
+)
+
+func (err KError) Error() string {
+	// Error messages stolen/adapted from
+	// https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol
+	switch err {
+	case ErrNoError:
+		return "kafka server: Not an error, why are you printing me?"
+	case ErrUnknown:
+		return "kafka server: Unexpected (unknown?) server error."
+	case ErrOffsetOutOfRange:
+		return "kafka server: The requested offset is outside the range of offsets maintained by the server for the given topic/partition."
+	case ErrInvalidMessage:
+		return "kafka server: Message contents does not match its CRC."
+	case ErrUnknownTopicOrPartition:
+		return "kafka server: Request was for a topic or partition that does not exist on this broker."
+	case ErrInvalidMessageSize:
+		return "kafka server: The message has a negative size."
+	case ErrLeaderNotAvailable:
+		return "kafka server: In the middle of a leadership election, there is currently no leader for this partition and hence it is unavailable for writes."
+	case ErrNotLeaderForPartition:
+		return "kafka server: Tried to send a message to a replica that is not the leader for some partition. Your metadata is out of date."
+	case ErrRequestTimedOut:
+		return "kafka server: Request exceeded the user-specified time limit in the request."
+	case ErrBrokerNotAvailable:
+		return "kafka server: Broker not available. Not a client facing error, we should never receive this!!!"
+	case ErrReplicaNotAvailable:
+		return "kafka server: Replica infomation not available, one or more brokers are down."
+	case ErrMessageSizeTooLarge:
+		return "kafka server: Message was too large, server rejected it to avoid allocation error."
+	case ErrStaleControllerEpochCode:
+		return "kafka server: StaleControllerEpochCode (internal error code for broker-to-broker communication)."
+	case ErrOffsetMetadataTooLarge:
+		return "kafka server: Specified a string larger than the configured maximum for offset metadata."
+	case ErrOffsetsLoadInProgress:
+		return "kafka server: The broker is still loading offsets after a leader change for that offset's topic partition."
+	case ErrConsumerCoordinatorNotAvailable:
+		return "kafka server: Offset's topic has not yet been created."
+	case ErrNotCoordinatorForConsumer:
+		return "kafka server: Request was for a consumer group that is not coordinated by this broker."
+	case ErrInvalidTopic:
+		return "kafka server: The request attempted to perform an operation on an invalid topic."
+	case ErrMessageSetSizeTooLarge:
+		return "kafka server: The request included message batch larger than the configured segment size on the server."
+	case ErrNotEnoughReplicas:
+		return "kafka server: Messages are rejected since there are fewer in-sync replicas than required."
+	case ErrNotEnoughReplicasAfterAppend:
+		return "kafka server: Messages are written to the log, but to fewer in-sync replicas than required."
+	case ErrInvalidRequiredAcks:
+		return "kafka server: The number of required acks is invalid (should be either -1, 0, or 1)."
+	case ErrIllegalGeneration:
+		return "kafka server: The provided generation id is not the current generation."
+	case ErrInconsistentGroupProtocol:
+		return "kafka server: The provider group protocol type is incompatible with the other members."
+	case ErrInvalidGroupId:
+		return "kafka server: The provided group id was empty."
+	case ErrUnknownMemberId:
+		return "kafka server: The provided member is not known in the current generation."
+	case ErrInvalidSessionTimeout:
+		return "kafka server: The provided session timeout is outside the allowed range."
+	case ErrRebalanceInProgress:
+		return "kafka server: A rebalance for the group is in progress. Please re-join the group."
+	case ErrInvalidCommitOffsetSize:
+		return "kafka server: The provided commit metadata was too large."
+	case ErrTopicAuthorizationFailed:
+		return "kafka server: The client is not authorized to access this topic."
+	case ErrGroupAuthorizationFailed:
+		return "kafka server: The client is not authorized to access this group."
+	case ErrClusterAuthorizationFailed:
+		return "kafka server: The client is not authorized to send this request type."
+	}
+
+	return fmt.Sprintf("Unknown error, how did this happen? Error code = %d", err)
+}

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -123,6 +123,7 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 
 	// Now get the first set of offsets and start a goroutine to continually check them
 	client.getOffsets()
+	client.getConsumerOffsets()
 	client.brokerOffsetTicker = time.NewTicker(time.Duration(client.app.Config.Tickers.BrokerOffsets) * time.Second)
 	go func() {
 		for _ = range client.brokerOffsetTicker.C {
@@ -187,6 +188,114 @@ func timeoutSendOffset(offsetChannel chan *protocol.PartitionOffset, offset *pro
 	case offsetChannel <- offset:
 	case <-timeout:
 	}
+}
+
+func (client *KafkaClient) getConsumerOffsets() error {
+	requests := make(map[int32]*sarama.ListGroupsRequest)
+	brokers := make(map[int32]*sarama.Broker)
+
+	client.topicMapLock.RLock()
+
+	// for each broker, the groups that it manages
+	for topic, partitions := range client.topicMap {
+		for i := 0; i < partitions; i++ {
+			broker, err := client.client.Leader(topic, int32(i))
+			if err != nil {
+				client.topicMapLock.RUnlock()
+				log.Errorf("Topic leader error on %s:%v: %v", topic, int32(i), err)
+				return err
+			}
+			if _, ok := requests[broker.ID()]; !ok {
+				requests[broker.ID()] = &sarama.ListGroupsRequest{}
+			}
+			brokers[broker.ID()] = broker
+		}
+	}
+
+	// Send out the OffsetFetchRequest to each broker for all the partitions it is leader for
+	// The results go to the offset storage module
+	var wg sync.WaitGroup
+
+	fetchConsumerOffsets := func(brokerID int32, request *sarama.ListGroupsRequest) {
+		defer wg.Done()
+		response, err := brokers[brokerID].ListGroups(request)
+		if err != nil {
+			log.Errorf("Cannot fetch offsets from broker %v: %v", brokerID, err)
+			_ = brokers[brokerID].Close()
+			return
+		}
+
+		// for each group, fetch a description of it
+		for group, groupType := range response.Groups {
+			if groupType == "consumer" {
+				describeRequest := new(sarama.DescribeGroupsRequest)
+				describeRequest.AddGroup(group)
+
+				describeResponse, err := brokers[brokerID].DescribeGroups(describeRequest)
+				if err != nil {
+					log.Errorf("Cannot fetch consumer desc from broker %v: %v", brokerID, err)
+				} else {
+					for _, description := range describeResponse.Groups {
+						for _, member := range description.Members {
+							// sarama doesn't decode the description for us
+							// so we have imported and used some sarama decoding
+							// stuff to do it here.
+							pd := realDecoder { raw: member.MemberAssignment }
+							memberAssignment := new(ConsumerGroupMemberAssignment)
+							memberAssignment.decode(&pd)
+
+							for topic, partitions := range memberAssignment.Topics {
+								// populate request with group, topic, and all partitions
+								offsetRequest := new(sarama.OffsetFetchRequest)
+								offsetRequest.Version = 1
+								offsetRequest.ConsumerGroup = group
+
+								for p := range partitions {
+									offsetRequest.AddPartition(topic, int32(p))
+								}
+
+								offsetResponse, err := brokers[brokerID].FetchOffset(offsetRequest)
+								if err != nil {
+									log.Errorf("Cannot fetch consumer offsetResponse from broker %v: %v", brokerID, err)
+								}
+
+								// send each (topic, partition, group, offset) to the storage module.
+								// this means burrow starts with a current view of all partitions,
+								// rather than starting at -1 and only discovering the current offset
+								// when the application next commits an offset.
+								for consumedTopic, offsets := range offsetResponse.Blocks {
+									for partition, offset := range offsets {
+										ts := time.Now().Unix() * 1000
+										offset := &protocol.PartitionOffset{
+											Cluster:             client.cluster,
+											Topic:               consumedTopic,
+											Partition:           partition,
+											Group:               group,
+											Offset:              offset.Offset,
+											Timestamp:           ts,
+											TopicPartitionCount: client.topicMap[topic],
+										}
+
+										log.Debugf("OffsetFetchRequest: group: %s topic: %v partition: %v offset: %v (group: %v)", group, consumedTopic, partition, offset.Offset, offset.Group)
+										timeoutSendOffset(client.app.Storage.offsetChannel, offset, 1)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	for brokerID, request := range requests {
+		wg.Add(1)
+		go fetchConsumerOffsets(brokerID, request)
+	}
+
+	wg.Wait()
+	client.topicMapLock.RUnlock()
+	return nil
 }
 
 // This function performs massively parallel OffsetRequests, which is better than Sarama's internal implementation,
@@ -349,6 +458,9 @@ func (client *KafkaClient) processConsumerOffsetsMessage(msg *sarama.ConsumerMes
 	}
 
 	// fmt.Printf("[%s,%s,%v]::OffsetAndMetadata[%v,%s,%v]\n", group, topic, partition, offset, metadata, timestamp)
+
+	log.Debugf("__consumer_offsets: group: %s topic: %s partition: %v offset: %v", group, topic, partition, offset)
+
 	partitionOffset := &protocol.PartitionOffset{
 		Cluster:   client.cluster,
 		Topic:     topic,

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -13,6 +13,8 @@ package main
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
 	"encoding/binary"
 	"errors"
 	"github.com/Shopify/sarama"
@@ -49,7 +51,25 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 	profile := app.Config.Clientprofile[app.Config.Kafka[cluster].Clientprofile]
 	clientConfig.ClientID = profile.ClientID
 	clientConfig.Net.TLS.Enable = profile.TLS
-	clientConfig.Net.TLS.Config = &tls.Config{}
+	if profile.TLSCertFilePath != "" {
+		caCert, err := ioutil.ReadFile(profile.TLSCAFilePath)
+		if err != nil {
+			return nil, err
+		}
+		cert, err := tls.LoadX509KeyPair(profile.TLSCertFilePath, profile.TLSKeyFilePath)
+		if err != nil {
+			return nil, err
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		clientConfig.Net.TLS.Config = &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			RootCAs: caCertPool,
+		}
+		clientConfig.Net.TLS.Config.BuildNameToCertificate()
+	} else {
+		clientConfig.Net.TLS.Config = &tls.Config{}
+	}
 	clientConfig.Net.TLS.Config.InsecureSkipVerify = profile.TLSNoVerify
 
 	sclient, err := sarama.NewClient(app.Config.Kafka[cluster].Brokers, clientConfig)

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -51,7 +51,9 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 	profile := app.Config.Clientprofile[app.Config.Kafka[cluster].Clientprofile]
 	clientConfig.ClientID = profile.ClientID
 	clientConfig.Net.TLS.Enable = profile.TLS
-	if profile.TLSCertFilePath != "" {
+	if profile.TLSCertFilePath == "" || profile.TLSKeyFilePath == "" || profile.TLSCAFilePath == "" {
+		clientConfig.Net.TLS.Config = &tls.Config{}
+	} else {
 		caCert, err := ioutil.ReadFile(profile.TLSCAFilePath)
 		if err != nil {
 			return nil, err
@@ -67,8 +69,6 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 			RootCAs: caCertPool,
 		}
 		clientConfig.Net.TLS.Config.BuildNameToCertificate()
-	} else {
-		clientConfig.Net.TLS.Config = &tls.Config{}
 	}
 	clientConfig.Net.TLS.Config.InsecureSkipVerify = profile.TLSNoVerify
 

--- a/main.go
+++ b/main.go
@@ -60,8 +60,10 @@ func burrowMain() int {
 	createPidFile(appContext.Config.General.LogDir + "/" + appContext.Config.General.PIDFile)
 	defer removePidFile(appContext.Config.General.LogDir + "/" + appContext.Config.General.PIDFile)
 
-	// Set up stderr/stdout to go to a separate log file
-	openOutLog(appContext.Config.General.LogDir + "/burrow.out")
+	// Set up stderr/stdout to go to a separate log file, if enabled
+	if appContext.Config.General.StdoutLogfile != "" {
+		openOutLog(appContext.Config.General.LogDir + "/" + appContext.Config.General.StdoutLogfile)
+	}
 	fmt.Println("Started Burrow at", time.Now().Format("January 2, 2006 at 3:04pm (MST)"))
 
 	// If a logging config is specified, replace the existing loggers

--- a/notifier/email_notifier.go
+++ b/notifier/email_notifier.go
@@ -40,6 +40,10 @@ func (emailer *EmailNotifier) NotifierName() string {
 }
 
 func (emailer *EmailNotifier) Notify(msg Message) error {
+	if emailer.Ignore(msg) {
+		return nil
+	}
+
 	if emailer.auth == nil {
 		switch emailer.AuthType {
 		case "plain":

--- a/notifier/http_notifier.go
+++ b/notifier/http_notifier.go
@@ -20,19 +20,24 @@ import (
 	"net/http"
 	"text/template"
 	"time"
+	"fmt"
 )
 
 type HttpNotifier struct {
-	Url                string
-	TemplatePostFile   string
-	TemplateDeleteFile string
+	RequestOpen        HttpNotifierRequest
+	RequestClose       HttpNotifierRequest
 	Threshold          int
-	SendDelete         bool
+	SendClose          bool
 	Extras             map[string]string
 	HttpClient         *http.Client
-	templatePost       *template.Template
-	templateDelete     *template.Template
 	groupIds           map[string]map[string]Event
+}
+
+type HttpNotifierRequest struct {
+	Url string
+	TemplateFile string
+	Method string
+	template *template.Template
 }
 
 type Event struct {
@@ -57,23 +62,16 @@ func (notifier *HttpNotifier) Notify(msg Message) error {
 		"maxlag":          maxLagHelper,
 	}
 
-	if notifier.templatePost == nil {
-		// Compile the templates
-		templatePost, err := template.New("post").Funcs(fmap).ParseFiles(notifier.TemplatePostFile)
-		if err != nil {
-			log.Criticalf("Cannot parse HTTP notifier POST template: %v", err)
-			return err
-		}
-		notifier.templatePost = templatePost.Templates()[0]
+	err := notifier.RequestOpen.ensureTemplateCompiled("post", fmap)
+	if err != nil {
+		log.Criticalf("Cannot parse HTTP notifier open template: %v", err)
+		return err
 	}
 
-	if notifier.templateDelete == nil {
-		templateDelete, err := template.New("delete").Funcs(fmap).ParseFiles(notifier.TemplateDeleteFile)
-		if err != nil {
-			log.Criticalf("Cannot parse HTTP notifier DELETE template: %v", err)
-			return err
-		}
-		notifier.templateDelete = templateDelete.Templates()[0]
+	err = notifier.RequestClose.ensureTemplateCompiled("delete", fmap)
+	if err != nil {
+		log.Criticalf("Cannot parse HTTP notifier close template: %v", err)
+		return err
 	}
 
 	if notifier.groupIds == nil {
@@ -91,7 +89,7 @@ func (notifier *HttpNotifier) sendConsumerGroupStatusNotify(msg Message) error {
 	// We only use IDs if we are sending deletes
 	idStr := ""
 	startTime := time.Now()
-	if notifier.SendDelete {
+	if notifier.SendClose {
 		if _, ok := notifier.groupIds[msg.Cluster]; !ok {
 			// Create the cluster map
 			notifier.groupIds[msg.Cluster] = make(map[string]Event)
@@ -111,8 +109,7 @@ func (notifier *HttpNotifier) sendConsumerGroupStatusNotify(msg Message) error {
 	}
 
 	// NOTE - I'm leaving the JsonEncode item in here so as not to break compatibility. New helpers go in the FuncMap above
-	bytesToSend := new(bytes.Buffer)
-	err := notifier.templatePost.Execute(bytesToSend, struct {
+	err := notifier.RequestOpen.send(struct {
 		Cluster    string
 		Group      string
 		Id         string
@@ -128,36 +125,15 @@ func (notifier *HttpNotifier) sendConsumerGroupStatusNotify(msg Message) error {
 		Extras:     notifier.Extras,
 		Result:     msg,
 		JsonEncode: templateJsonEncoder,
-	})
+	}, notifier.HttpClient, fmt.Sprintf("open for group %s in cluster %s at severity %v (Id %s)", msg.Group, msg.Cluster, msg.Status, idStr))
+
 	if err != nil {
-		log.Errorf("Failed to assemble POST: %v", err)
 		return err
 	}
 
-	// Send POST to HTTP endpoint
-	req, err := http.NewRequest("POST", notifier.Url, bytesToSend)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := notifier.HttpClient.Do(req)
-	if err != nil {
-		log.Errorf("Failed to send POST for group %s in cluster %s at severity %v (Id %s): %v", msg.Group, msg.Cluster, msg.Status, idStr, err)
-		return err
-	}
-	io.Copy(ioutil.Discard, resp.Body)
-	resp.Body.Close()
-
-	if (resp.StatusCode >= 200) && (resp.StatusCode <= 299) {
-		log.Debugf("Sent POST for group %s in cluster %s at severity %v (Id %s)", msg.Group, msg.Cluster, msg.Status, idStr)
-	} else {
-		log.Errorf("Failed to send POST for group %s in cluster %s at severity %v (Id %s): %s", msg.Group,
-			msg.Cluster, msg.Status, idStr, resp.Status)
-	}
-
-	if notifier.SendDelete && (msg.Status == protocol.StatusOK) {
+	if notifier.SendClose && (msg.Status == protocol.StatusOK) {
 		if _, ok := notifier.groupIds[msg.Cluster][msg.Group]; ok {
-			// Send DELETE to HTTP endpoint
-			bytesToSend := new(bytes.Buffer)
-			err := notifier.templateDelete.Execute(bytesToSend, struct {
+			err := notifier.RequestClose.send(struct {
 				Cluster string
 				Group   string
 				Id      string
@@ -169,36 +145,59 @@ func (notifier *HttpNotifier) sendConsumerGroupStatusNotify(msg Message) error {
 				Id:      notifier.groupIds[msg.Cluster][msg.Group].Id,
 				Start:   notifier.groupIds[msg.Cluster][msg.Group].Start,
 				Extras:  notifier.Extras,
-			})
+			}, notifier.HttpClient, fmt.Sprintf("close for group %s in cluster %s (Id %s)", msg.Group,
+					msg.Cluster, notifier.groupIds[msg.Cluster][msg.Group].Id))
+
 			if err != nil {
-				log.Errorf("Failed to assemble DELETE for group %s in cluster %s (Id %s): %v", msg.Group,
-					msg.Cluster, notifier.groupIds[msg.Cluster][msg.Group].Id, err)
 				return err
-			}
-
-			req, err := http.NewRequest("DELETE", notifier.Url, bytesToSend)
-			req.Header.Set("Content-Type", "application/json")
-
-			resp, err := notifier.HttpClient.Do(req)
-			if err != nil {
-				log.Errorf("Failed to send DELETE for group %s in cluster %s (Id %s): %v", msg.Group,
-					msg.Cluster, notifier.groupIds[msg.Cluster][msg.Group].Id, err)
-				return err
-			}
-			io.Copy(ioutil.Discard, resp.Body)
-			resp.Body.Close()
-
-			if (resp.StatusCode >= 200) && (resp.StatusCode <= 299) {
-				log.Debugf("Sent DELETE for group %s in cluster %s (Id %s)", msg.Group, msg.Cluster,
-					notifier.groupIds[msg.Cluster][msg.Group].Id)
-			} else {
-				log.Errorf("Failed to send DELETE for group %s in cluster %s (Id %s): %s", msg.Group,
-					msg.Cluster, notifier.groupIds[msg.Cluster][msg.Group].Id, resp.Status)
 			}
 
 			// Remove ID for group that is now clear
 			delete(notifier.groupIds[msg.Cluster], msg.Group)
 		}
 	}
+	return nil
+}
+
+func (request *HttpNotifierRequest) ensureTemplateCompiled(name string, fmap template.FuncMap) error {
+	if request.template != nil {
+		return nil
+	}
+
+	template, err := template.New(name).Funcs(fmap).ParseFiles(request.TemplateFile)
+	if err != nil {
+		return err
+	}
+	request.template = template.Templates()[0]
+
+	return nil
+}
+
+func (request *HttpNotifierRequest) send(templateData interface{}, httpClient *http.Client, details string) error {
+	bytesToSend := new(bytes.Buffer)
+	err := request.template.Execute(bytesToSend, templateData)
+	if err != nil {
+		log.Errorf("Failed to assemble %s: %v", details, err)
+		return err
+	}
+
+	// Send POST to HTTP endpoint
+	req, err := http.NewRequest(request.Method, request.Url, bytesToSend)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		log.Errorf("Failed to send %s: %v", details, err)
+		return err
+	}
+	io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
+
+	if (resp.StatusCode >= 200) && (resp.StatusCode <= 299) {
+		log.Debugf("Sent %s", details)
+	} else {
+		log.Errorf("Failed to send %s: %s", details, resp.Status)
+	}
+
 	return nil
 }

--- a/notifier/slack_notifier.go
+++ b/notifier/slack_notifier.go
@@ -62,6 +62,10 @@ func (slack *SlackNotifier) Ignore(msg Message) bool {
 }
 
 func (slack *SlackNotifier) Notify(msg Message) error {
+	if slack.Ignore(msg) {
+		return nil
+	}
+
 	if slack.groupMsgs == nil {
 		slack.groupMsgs = make(map[string]Message)
 	}

--- a/notify_center.go
+++ b/notify_center.go
@@ -114,9 +114,7 @@ func StopNotifiers(app *ApplicationContext) {
 func (nc *NotifyCenter) handleEvaluationResponse(result *protocol.ConsumerGroupStatus) {
 	msg := notifier.Message(*result)
 	for _, notifier := range nc.notifiers {
-		if !notifier.Ignore(msg) {
-			notifier.Notify(msg)
-		}
+		notifier.Notify(msg)
 	}
 }
 

--- a/notify_center.go
+++ b/notify_center.go
@@ -36,7 +36,7 @@ type NotifyCenter struct {
 
 func LoadNotifiers(app *ApplicationContext) error {
 	notifiers := []notifier.Notifier{}
-	if app.Config.Httpnotifier.Url != "" {
+	if app.Config.Httpnotifier.UrlOpen != "" {
 		if httpNotifier, err := NewHttpNotifier(app); err == nil {
 			notifiers = append(notifiers, httpNotifier)
 		}
@@ -220,11 +220,18 @@ func NewHttpNotifier(app *ApplicationContext) (*notifier.HttpNotifier, error) {
 	}
 
 	return &notifier.HttpNotifier{
-		Url:                httpConfig.Url,
+		RequestOpen: notifier.HttpNotifierRequest{
+			Url:          httpConfig.UrlOpen,
+			Method:       httpConfig.MethodOpen,
+			TemplateFile: httpConfig.TemplateOpen,
+		},
+		RequestClose: notifier.HttpNotifierRequest{
+			Url:          httpConfig.UrlClose,
+			Method:       httpConfig.MethodClose,
+			TemplateFile: httpConfig.TemplateClose,
+		},
 		Threshold:          httpConfig.PostThreshold,
-		SendDelete:         httpConfig.SendDelete,
-		TemplatePostFile:   httpConfig.TemplatePost,
-		TemplateDeleteFile: httpConfig.TemplateDelete,
+		SendClose:          httpConfig.SendClose,
 		Extras:             extras,
 		HttpClient: &http.Client{
 			Timeout: time.Duration(httpConfig.Timeout) * time.Second,

--- a/offsets_store.go
+++ b/offsets_store.go
@@ -274,6 +274,10 @@ func (storage *OffsetStorage) addConsumerOffset(offset *protocol.PartitionOffset
 
 		// Prevent new commits that are too fast (less than the min-distance config) if the last offset was not artificial
 		if (!lastOffset.Artificial) && (timestampDifference >= 0) && (timestampDifference < (storage.app.Config.Lagcheck.MinDistance * 1000)) {
+			// Store the current offset before dropping the ConsumerOffset.
+			// This might be the last offset we receive for a while, and it can help us decide if the consumer is STOPPED because
+			// it has processed all messages.
+			lastOffset.MaxOffset = offset.Offset
 			clusterOffsets.consumerLock.Unlock()
 			log.Debugf("Dropped offset (mindistance): cluster=%s topic=%s partition=%v group=%s timestamp=%v offset=%v tsdiff=%v lag=%v",
 				offset.Cluster, offset.Topic, offset.Partition, offset.Group, offset.Timestamp, offset.Offset,
@@ -294,6 +298,7 @@ func (storage *OffsetStorage) addConsumerOffset(offset *protocol.PartitionOffset
 	if consumerPartitionRing.Value == nil {
 		consumerPartitionRing.Value = &protocol.ConsumerOffset{
 			Offset:     offset.Offset,
+			MaxOffset:  0,
 			Timestamp:  offset.Timestamp,
 			Lag:        partitionLag,
 			Artificial: false,
@@ -301,6 +306,7 @@ func (storage *OffsetStorage) addConsumerOffset(offset *protocol.PartitionOffset
 	} else {
 		ringval, _ := consumerPartitionRing.Value.(*protocol.ConsumerOffset)
 		ringval.Offset = offset.Offset
+		ringval.MaxOffset = 0
 		ringval.Timestamp = offset.Timestamp
 		ringval.Lag = partitionLag
 		ringval.Artificial = false
@@ -388,13 +394,28 @@ func (storage *OffsetStorage) evaluateGroup(cluster string, group string, result
 			if lastOffset.Offset >= clusterMap.broker[topic][partition].Offset {
 				ringval, _ := offsetRing.Value.(*protocol.ConsumerOffset)
 				ringval.Offset = lastOffset.Offset
+				ringval.MaxOffset = lastOffset.MaxOffset
 				ringval.Timestamp = time.Now().Unix() * 1000
 				ringval.Lag = 0
 				ringval.Artificial = true
 				partitions[partition] = partitions[partition].Next()
 
-				log.Tracef("Artificial offset: cluster=%s topic=%s partition=%v group=%s timestamp=%v offset=%v lag=0",
-					cluster, topic, partition, group, ringval.Timestamp, lastOffset.Offset)
+				log.Tracef("Artificial offset: cluster=%s topic=%s partition=%v group=%s timestamp=%v offset=%v max_offset=%v lag=0",
+					cluster, topic, partition, group, ringval.Timestamp, lastOffset.Offset, lastOffset.MaxOffset)
+
+				// Add an artificial offset commit if the consumer has no lag against the current broker offset
+				// This time we check the maxOffset seen in the last window (piggybacked in the ConsumerOffset).
+			} else if lastOffset.MaxOffset >= clusterMap.broker[topic][partition].Offset {
+				ringval, _ := offsetRing.Value.(*protocol.ConsumerOffset)
+				ringval.Offset = lastOffset.MaxOffset
+				ringval.MaxOffset = 0
+				ringval.Timestamp = time.Now().Unix() * 1000
+				ringval.Lag = 0
+				ringval.Artificial = true
+				partitions[partition] = partitions[partition].Next()
+
+				log.Tracef("Artificial max offset: cluster=%s topic=%s partition=%v group=%s timestamp=%v offset=%v max_offset=%v lag=0",
+					cluster, topic, partition, group, ringval.Timestamp, lastOffset.Offset, lastOffset.MaxOffset)
 			}
 
 			// Pull out the offsets once so we can unlock the map

--- a/packet_decoder.go
+++ b/packet_decoder.go
@@ -1,0 +1,45 @@
+package main
+
+// PacketDecoder is the interface providing helpers for reading with Kafka's encoding rules.
+// Types implementing Decoder only need to worry about calling methods like GetString,
+// not about how a string is represented in Kafka.
+type packetDecoder interface {
+	// Primitives
+	getInt8() (int8, error)
+	getInt16() (int16, error)
+	getInt32() (int32, error)
+	getInt64() (int64, error)
+	getArrayLength() (int, error)
+
+	// Collections
+	getBytes() ([]byte, error)
+	getString() (string, error)
+	getInt32Array() ([]int32, error)
+	getInt64Array() ([]int64, error)
+	getStringArray() ([]string, error)
+
+	// Subsets
+	remaining() int
+	getSubset(length int) (packetDecoder, error)
+
+	// Stacks, see PushDecoder
+	push(in pushDecoder) error
+	pop() error
+}
+
+// PushDecoder is the interface for decoding fields like CRCs and lengths where the validity
+// of the field depends on what is after it in the packet. Start them with PacketDecoder.Push() where
+// the actual value is located in the packet, then PacketDecoder.Pop() them when all the bytes they
+// depend upon have been decoded.
+type pushDecoder interface {
+	// Saves the offset into the input buffer as the location to actually read the calculated value when able.
+	saveOffset(in int)
+
+	// Returns the length of data to reserve for the input of this encoder (eg 4 bytes for a CRC32).
+	reserveLength() int
+
+	// Indicates that all required data is now available to calculate and check the field.
+	// SaveOffset is guaranteed to have been called first. The implementation should read ReserveLength() bytes
+	// of data from the saved offset, and verify it based on the data between the saved offset and curOffset.
+	check(curOffset int, buf []byte) error
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -29,6 +29,7 @@ type ConsumerOffset struct {
 	Timestamp  int64 `json:"timestamp"`
 	Lag        int64 `json:"lag"`
 	Artificial bool  `json:"-"`
+	MaxOffset  int64 `json:"max_offset"`
 }
 
 type StatusConstant int

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+type realDecoder struct {
+	raw   []byte
+	off   int
+	stack []pushDecoder
+}
+
+// primitives
+
+func (rd *realDecoder) getInt8() (int8, error) {
+	if rd.remaining() < 1 {
+		rd.off = len(rd.raw)
+		return -1, ErrInsufficientData
+	}
+	tmp := int8(rd.raw[rd.off])
+	rd.off++
+	return tmp, nil
+}
+
+func (rd *realDecoder) getInt16() (int16, error) {
+	if rd.remaining() < 2 {
+		rd.off = len(rd.raw)
+		return -1, ErrInsufficientData
+	}
+	tmp := int16(binary.BigEndian.Uint16(rd.raw[rd.off:]))
+	rd.off += 2
+	return tmp, nil
+}
+
+func (rd *realDecoder) getInt32() (int32, error) {
+	if rd.remaining() < 4 {
+		rd.off = len(rd.raw)
+		return -1, ErrInsufficientData
+	}
+	tmp := int32(binary.BigEndian.Uint32(rd.raw[rd.off:]))
+	rd.off += 4
+	return tmp, nil
+}
+
+func (rd *realDecoder) getInt64() (int64, error) {
+	if rd.remaining() < 8 {
+		rd.off = len(rd.raw)
+		return -1, ErrInsufficientData
+	}
+	tmp := int64(binary.BigEndian.Uint64(rd.raw[rd.off:]))
+	rd.off += 8
+	return tmp, nil
+}
+
+func (rd *realDecoder) getArrayLength() (int, error) {
+	if rd.remaining() < 4 {
+		rd.off = len(rd.raw)
+		return -1, ErrInsufficientData
+	}
+	tmp := int(binary.BigEndian.Uint32(rd.raw[rd.off:]))
+	rd.off += 4
+	if tmp > rd.remaining() {
+		rd.off = len(rd.raw)
+		return -1, ErrInsufficientData
+	} else if tmp > 2*math.MaxUint16 {
+		return -1, PacketDecodingError{"invalid array length"}
+	}
+	return tmp, nil
+}
+
+// collections
+
+func (rd *realDecoder) getBytes() ([]byte, error) {
+	tmp, err := rd.getInt32()
+
+	if err != nil {
+		return nil, err
+	}
+
+	n := int(tmp)
+
+	switch {
+	case n < -1:
+		return nil, PacketDecodingError{"invalid byteslice length"}
+	case n == -1:
+		return nil, nil
+	case n == 0:
+		return make([]byte, 0), nil
+	case n > rd.remaining():
+		rd.off = len(rd.raw)
+		return nil, ErrInsufficientData
+	}
+
+	tmpStr := rd.raw[rd.off : rd.off+n]
+	rd.off += n
+	return tmpStr, nil
+}
+
+func (rd *realDecoder) getString() (string, error) {
+	tmp, err := rd.getInt16()
+
+	if err != nil {
+		return "", err
+	}
+
+	n := int(tmp)
+
+	switch {
+	case n < -1:
+		return "", PacketDecodingError{"invalid string length"}
+	case n == -1:
+		return "", nil
+	case n == 0:
+		return "", nil
+	case n > rd.remaining():
+		rd.off = len(rd.raw)
+		return "", ErrInsufficientData
+	}
+
+	tmpStr := string(rd.raw[rd.off : rd.off+n])
+	rd.off += n
+	return tmpStr, nil
+}
+
+func (rd *realDecoder) getInt32Array() ([]int32, error) {
+	if rd.remaining() < 4 {
+		rd.off = len(rd.raw)
+		return nil, ErrInsufficientData
+	}
+	n := int(binary.BigEndian.Uint32(rd.raw[rd.off:]))
+	rd.off += 4
+
+	if rd.remaining() < 4*n {
+		rd.off = len(rd.raw)
+		return nil, ErrInsufficientData
+	}
+
+	if n == 0 {
+		return nil, nil
+	}
+
+	if n < 0 {
+		return nil, PacketDecodingError{"invalid array length"}
+	}
+
+	ret := make([]int32, n)
+	for i := range ret {
+		ret[i] = int32(binary.BigEndian.Uint32(rd.raw[rd.off:]))
+		rd.off += 4
+	}
+	return ret, nil
+}
+
+func (rd *realDecoder) getInt64Array() ([]int64, error) {
+	if rd.remaining() < 4 {
+		rd.off = len(rd.raw)
+		return nil, ErrInsufficientData
+	}
+	n := int(binary.BigEndian.Uint32(rd.raw[rd.off:]))
+	rd.off += 4
+
+	if rd.remaining() < 8*n {
+		rd.off = len(rd.raw)
+		return nil, ErrInsufficientData
+	}
+
+	if n == 0 {
+		return nil, nil
+	}
+
+	if n < 0 {
+		return nil, PacketDecodingError{"invalid array length"}
+	}
+
+	ret := make([]int64, n)
+	for i := range ret {
+		ret[i] = int64(binary.BigEndian.Uint64(rd.raw[rd.off:]))
+		rd.off += 8
+	}
+	return ret, nil
+}
+
+func (rd *realDecoder) getStringArray() ([]string, error) {
+	if rd.remaining() < 4 {
+		rd.off = len(rd.raw)
+		return nil, ErrInsufficientData
+	}
+	n := int(binary.BigEndian.Uint32(rd.raw[rd.off:]))
+	rd.off += 4
+
+	if n == 0 {
+		return nil, nil
+	}
+
+	if n < 0 {
+		return nil, PacketDecodingError{"invalid array length"}
+	}
+
+	ret := make([]string, n)
+	for i := range ret {
+		if str, err := rd.getString(); err != nil {
+			return nil, err
+		} else {
+			ret[i] = str
+		}
+	}
+	return ret, nil
+}
+
+// subsets
+
+func (rd *realDecoder) remaining() int {
+	return len(rd.raw) - rd.off
+}
+
+func (rd *realDecoder) getSubset(length int) (packetDecoder, error) {
+	if length < 0 {
+		return nil, PacketDecodingError{"invalid subset size"}
+	} else if length > rd.remaining() {
+		rd.off = len(rd.raw)
+		return nil, ErrInsufficientData
+	}
+
+	start := rd.off
+	rd.off += length
+	return &realDecoder{raw: rd.raw[start:rd.off]}, nil
+}
+
+// stacks
+
+func (rd *realDecoder) push(in pushDecoder) error {
+	in.saveOffset(rd.off)
+
+	reserve := in.reserveLength()
+	if rd.remaining() < reserve {
+		rd.off = len(rd.raw)
+		return ErrInsufficientData
+	}
+
+	rd.stack = append(rd.stack, in)
+
+	rd.off += reserve
+
+	return nil
+}
+
+func (rd *realDecoder) pop() error {
+	// this is go's ugly pop pattern (the inverse of append)
+	in := rd.stack[len(rd.stack)-1]
+	rd.stack = rd.stack[:len(rd.stack)-1]
+
+	return in.check(rd.off, rd.raw)
+}


### PR DESCRIPTION
burrow consumes from `__consumer_offsets` when it starts.

If a consumer doesn't commit an offset for a partition then burrow won't see it. It will report a lower total offset for the consumer group until it finally offsets.

Instead, before starting consuming, I'm querying the offsets with this basic structure:

```
for broker in brokers:
  for group, group_type in broker.ListGroups():
    if group_type == 'consumer':
      for description in broker.DescribeGroups(group):
        for member_assignment in description.members:
          for topic, partitions in  member_assignment.topics:
            for offset, partition in broker.FetchOffsets(group, partitions):
                client.app.storage.add(topic, group, partition, offset)
```

This takes a few seconds and populates all partition offsets.

Topic and consumer offset totals now match immediately.

```
% curl -s localhost:8000/v2/kafka/mayhem-streams/topic/lo-werphat--atlasdossubmissions-uploaded | jq -c .offsets[] | paste -s -d + - | bc -l                
210778

% curl -s localhost:8000/v2/kafka/mayhem-streams/consumer/lo-werphat-atlasdos-submissions-balancer-exetnovg/topic/lo-werphat--atlasdossubmissions-uploaded | jq -c .offsets[] | sed 's/-1/0/' | paste -s -d + - | bc -l
210778
```